### PR TITLE
convert TokenStream using Source.queue

### DIFF
--- a/src/main/java/akka/ask/Bootstrap.java
+++ b/src/main/java/akka/ask/Bootstrap.java
@@ -1,7 +1,5 @@
 package akka.ask;
 
-import akka.Done;
-import akka.actor.CoordinatedShutdown;
 import akka.ask.agent.application.AgentService;
 import akka.ask.common.KeyUtils;
 import akka.ask.indexer.application.RagIndexing;
@@ -14,8 +12,6 @@ import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.concurrent.CompletableFuture;
 
 @Setup
 public class Bootstrap implements ServiceSetup {
@@ -38,16 +34,6 @@ public class Bootstrap implements ServiceSetup {
 
     this.componentClient = componentClient;
     this.mongoClient = MongoClients.create(KeyUtils.readMongoDbUri());
-
-    CoordinatedShutdown.get(materializer.system()).addTask(
-      CoordinatedShutdown.PhaseServiceUnbind(),
-      "close-client", ()-> {
-        logger.debug("Closing mongo client");
-        mongoClient.close();
-        return CompletableFuture.completedFuture(Done.getInstance());
-      }
-    );
-
   }
 
   @Override

--- a/src/main/java/akka/ask/agent/application/AkkaStreamUtils.java
+++ b/src/main/java/akka/ask/agent/application/AkkaStreamUtils.java
@@ -1,0 +1,35 @@
+package akka.ask.agent.application;
+
+import akka.NotUsed;
+import akka.stream.javadsl.Source;
+import dev.langchain4j.service.TokenStream;
+
+
+public class AkkaStreamUtils {
+
+  /**
+   * Converts a TokenStream to an Akka Source.
+   * <p>
+   * This method will build an Akka Source that is fed with the tokens produced by TokenStream.
+   */
+  public static Source<StreamedResponse, NotUsed> toAkkaSource(TokenStream tokenStream) {
+    return
+      Source
+        .<StreamedResponse>queue(10000)
+        .mapMaterializedValue(queue -> {
+          // tokens emitted by tokenStream are passed to the queue
+          // that ultimately feeds the Akka Source
+          tokenStream
+            .onPartialResponse(msg -> queue.offer(StreamedResponse.partial(msg)))
+            .onCompleteResponse(res -> {
+              queue.offer(StreamedResponse.lastMessage(res.aiMessage().text(), res.tokenUsage().totalTokenCount()));
+              queue.complete();
+            })
+            .onError(queue::fail)
+            .start();
+
+          return NotUsed.getInstance();
+        });
+
+  }
+}

--- a/src/main/java/akka/ask/agent/application/ConversationHistoryView.java
+++ b/src/main/java/akka/ask/agent/application/ConversationHistoryView.java
@@ -37,7 +37,6 @@ public class ConversationHistoryView extends View {
   public static class ChatMessageUpdater extends TableUpdater<ChatMessages> {
 
     public Effect<ChatMessages> onEvent(SessionEvent event) {
-      logger.debug("Received session event: {}", event);
       return switch (event) {
         case SessionEvent.AiMessageAdded added -> aiMessage(added);
         case SessionEvent.UserMessageAdded added -> userMessage(added);

--- a/src/main/java/akka/ask/agent/application/StreamedResponse.java
+++ b/src/main/java/akka/ask/agent/application/StreamedResponse.java
@@ -1,0 +1,15 @@
+package akka.ask.agent.application;
+
+public record StreamedResponse(String content, int tokens, boolean finished) {
+  public static StreamedResponse partial(String content) {
+    return new StreamedResponse(content, 0, false);
+  }
+
+  public static StreamedResponse lastMessage(String content, int tokens) {
+    return new StreamedResponse(content, tokens, true);
+  }
+
+  public static StreamedResponse empty() {
+    return new StreamedResponse("", 0, true);
+  }
+}


### PR DESCRIPTION
Simplifies how we convert a TokenStream to an Akka Source. 

Instead of using, Source.actorRef we can use Source.queue. Much easier to follow for users not familiar with Akka streams.