### PR TITLE
User and AI message added as single Exchange

### DIFF
--- a/src/main/java/akka/ask/agent/api/AskHttpEndpoint.java
+++ b/src/main/java/akka/ask/agent/api/AskHttpEndpoint.java
@@ -1,18 +1,14 @@
 package akka.ask.agent.api;
 
 import akka.ask.agent.application.AgentService;
-import akka.ask.agent.application.ConversationHistoryView;
 import akka.ask.agent.application.StreamedResponse;
 import akka.http.javadsl.model.HttpResponse;
 import akka.javasdk.annotations.Acl;
-import akka.javasdk.annotations.http.Get;
 import akka.javasdk.annotations.http.HttpEndpoint;
 import akka.javasdk.annotations.http.Post;
 import akka.javasdk.client.ComponentClient;
 import akka.javasdk.http.HttpResponses;
 import akka.stream.Materializer;
-
-import java.util.concurrent.CompletionStage;
 
 @Acl(allow = @Acl.Matcher(principal = Acl.Principal.INTERNET))
 @HttpEndpoint("/api")

--- a/src/main/java/akka/ask/agent/application/ConversationHistoryView.java
+++ b/src/main/java/akka/ask/agent/application/ConversationHistoryView.java
@@ -49,13 +49,13 @@ public class ConversationHistoryView extends View {
     }
 
     private Effect<Session> aiMessage(SessionEvent.AiMessageAdded added) {
-      Message newMessage = new Message(added.content(), "ai", added.timeStamp().toEpochMilli());
+      Message newMessage = new Message(added.response(), "ai", added.timeStamp().toEpochMilli());
       var rowState = rowStateOrNew(added.userId(), added.sessionId());
       return effects().updateRow(rowState.add(newMessage));
     }
 
     private Effect<Session> userMessage(SessionEvent.UserMessageAdded added) {
-      Message newMessage = new Message(added.content(), "user", added.timeStamp().toEpochMilli());
+      Message newMessage = new Message(added.query(), "user", added.timeStamp().toEpochMilli());
       var rowState = rowStateOrNew(added.userId(), added.sessionId());
       return effects().updateRow(rowState.add(newMessage));
     }

--- a/src/main/java/akka/ask/agent/application/StreamedResponse.java
+++ b/src/main/java/akka/ask/agent/application/StreamedResponse.java
@@ -1,15 +1,16 @@
 package akka.ask.agent.application;
 
-public record StreamedResponse(String content, int tokens, boolean finished) {
+public record StreamedResponse(String content, int inputTokens, int outputTokens, boolean finished) {
+
   public static StreamedResponse partial(String content) {
-    return new StreamedResponse(content, 0, false);
+    return new StreamedResponse(content, 0, 0, false);
   }
 
-  public static StreamedResponse lastMessage(String content, int tokens) {
-    return new StreamedResponse(content, tokens, true);
+  public static StreamedResponse lastMessage(String content, int inputTokens, int outputTokens) {
+    return new StreamedResponse(content, inputTokens, outputTokens, true);
   }
 
   public static StreamedResponse empty() {
-    return new StreamedResponse("", 0, true);
+    return new StreamedResponse("", 0, 0, true);
   }
 }

--- a/src/main/java/akka/ask/agent/domain/SessionEvent.java
+++ b/src/main/java/akka/ask/agent/domain/SessionEvent.java
@@ -4,14 +4,14 @@ import java.time.Instant;
 import akka.javasdk.annotations.TypeName;
 
 public sealed interface SessionEvent {
-  @TypeName("ai-message-added")
-  public record AiMessageAdded(String userId, String sessionId, String content, long tokensUsed, Instant timeStamp)
-      implements SessionEvent {
-  }
 
   @TypeName("user-message-added")
-  public record UserMessageAdded(String userId, String sessionId, String content, long tokensUsed, Instant timeStamp)
+  public record UserMessageAdded(String userId, String sessionId, String query, int tokensUsed, Instant timeStamp)
       implements SessionEvent {
   }
 
+  @TypeName("ai-message-added")
+  public record AiMessageAdded(String userId, String sessionId, String response, int tokensUsed, Instant timeStamp)
+    implements SessionEvent {
+  }
 }


### PR DESCRIPTION
In this PR, the user question and AI response are sent to the SessionEntity together in a single command.

Before, we were first sending the user question and if the AI fails to answer, we end up with a 'broken' conversation where there is a question without a response. 

Now they are added as an exchange pair. Either we have both or we have none.