### PR TITLE
distributed indexing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.akka</groupId>
         <artifactId>akka-javasdk-parent</artifactId>
-        <version>3.2.3</version>
+        <version>3.2.3-15-50908c8f-SNAPSHOT</version>
     </parent>
 
     <groupId>akka.ask</groupId>

--- a/src/main/java/akka/ask/Bootstrap.java
+++ b/src/main/java/akka/ask/Bootstrap.java
@@ -2,6 +2,7 @@ package akka.ask;
 
 import akka.ask.agent.application.AgentService;
 import akka.ask.common.KeyUtils;
+import akka.ask.indexer.application.EmbeddingIndexer;
 import akka.javasdk.DependencyProvider;
 import akka.javasdk.ServiceSetup;
 import akka.javasdk.annotations.Setup;
@@ -43,9 +44,10 @@ public class Bootstrap implements ServiceSetup {
           return (T) new AgentService(componentClient, mongoClient);
         }
 
-        if (cls.equals(MongoClient.class)) {
-          return (T) mongoClient;
+        if (cls.equals(EmbeddingIndexer.class)) {
+          return (T) new EmbeddingIndexer(mongoClient);
         }
+
         return null;
       }
     };

--- a/src/main/java/akka/ask/indexer/api/IndexerEndpoint.java
+++ b/src/main/java/akka/ask/indexer/api/IndexerEndpoint.java
@@ -18,23 +18,39 @@ public class IndexerEndpoint {
 
   private final Logger logger = LoggerFactory.getLogger(getClass());
   private final ComponentClient componentClient;
+  private final String workflowId = "rag-indexing";
 
   public IndexerEndpoint(ComponentClient componentClient) {
-
     this.componentClient = componentClient;
   }
 
   @Post("/start")
   public CompletionStage<HttpResponse> startIndexation() {
-    return componentClient.forWorkflow("indexing")
+    return componentClient.forWorkflow(workflowId)
       .method(RagIndexingWorkflow::start)
       .invokeAsync()
       .thenApply(__ -> HttpResponses.accepted());
   }
 
+  @Post("/pause")
+  public CompletionStage<HttpResponse> pause() {
+    return componentClient.forWorkflow(workflowId)
+      .method(RagIndexingWorkflow::pause)
+      .invokeAsync()
+      .thenApply(__ -> HttpResponses.accepted());
+  }
+
+  @Post("/resume")
+  public CompletionStage<HttpResponse> resume() {
+    return componentClient.forWorkflow(workflowId)
+      .method(RagIndexingWorkflow::resume)
+      .invokeAsync()
+      .thenApply(__ -> HttpResponses.accepted());
+  }
+
   @Post("/abort")
-  public CompletionStage<HttpResponse> abortIndexation() {
-    return componentClient.forWorkflow("indexing")
+  public CompletionStage<HttpResponse> abort() {
+    return componentClient.forWorkflow(workflowId)
       .method(RagIndexingWorkflow::abort)
       .invokeAsync()
       .thenApply(__ -> HttpResponses.accepted());

--- a/src/main/java/akka/ask/indexer/application/EmbeddingIndexer.java
+++ b/src/main/java/akka/ask/indexer/application/EmbeddingIndexer.java
@@ -1,0 +1,98 @@
+package akka.ask.indexer.application;
+
+import akka.Done;
+import akka.ask.common.OpenAiUtils;
+import com.mongodb.client.MongoClient;
+import dev.langchain4j.data.document.BlankDocumentException;
+import dev.langchain4j.data.document.DefaultDocument;
+import dev.langchain4j.data.document.Document;
+import dev.langchain4j.data.document.DocumentSplitter;
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.document.parser.TextDocumentParser;
+import dev.langchain4j.data.document.splitter.DocumentByCharacterSplitter;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.openai.OpenAiEmbeddingModel;
+import dev.langchain4j.store.embedding.mongodb.MongoDbEmbeddingStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+public class EmbeddingIndexer {
+
+  private final OpenAiEmbeddingModel embeddingModel;
+  private final MongoDbEmbeddingStore embeddingStore;
+  private final DocumentSplitter splitter;
+
+  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private final CompletionStage<Done> futDone = CompletableFuture.completedFuture(Done.getInstance());
+
+  public EmbeddingIndexer(MongoClient mongoClient) {
+
+    this.embeddingModel = OpenAiUtils.embeddingModel();
+    this.embeddingStore =
+      MongoDbEmbeddingStore.builder()
+        .fromClient(mongoClient)
+        .databaseName("akka-docs")
+        .collectionName("embeddings")
+        .indexName("default")
+        .createIndex(true)
+        .build();
+
+    this.splitter = new DocumentByCharacterSplitter(500, 50, OpenAiUtils.buildTokenizer());
+  }
+
+
+
+  public CompletionStage<Done> indexFile(Path path) {
+    logger.debug("Indexing file: [{}]",  path.getFileName());
+    if (path.toString().isEmpty()) return futDone;
+    else {
+      try (InputStream input = Files.newInputStream(path)) {
+        // read file as input stream
+        Document doc = new TextDocumentParser().parse(input);
+        var docWithMetadata = new DefaultDocument(doc.text(), Metadata.metadata("src", path.getFileName().toString()));
+
+        var segments = splitter.split(docWithMetadata);
+        logger.debug("Created {} segments for document {}", segments.size(), path.getFileName());
+
+        return segments
+          .stream()
+          .reduce(
+            futDone,
+            (acc, seg) -> addSegment(seg),
+            (stage1, stage2) -> futDone
+          );
+
+      } catch (BlankDocumentException e) {
+        // some documents are blank, we need to skip them
+        return futDone;
+      } catch (Exception e) {
+        logger.error("Error reading file: [{}] - [{}]", path, e.getMessage());
+        return futDone;
+      }
+    }
+  }
+
+  private CompletionStage<Done> addSegment(TextSegment seg) {
+    // metadata key used to store file name
+    String srcKey = "src";
+    var fileName = seg.metadata().getString(srcKey);
+    return
+      CompletableFuture.supplyAsync(() -> embeddingModel.embed(seg))
+        .thenCompose(res ->
+          CompletableFuture.supplyAsync(() -> {
+            logger.debug("Segment embedded. Source file [{}]. Tokens usage: in [{}], out [{}]",
+              fileName,
+              res.tokenUsage().inputTokenCount(),
+              res.tokenUsage().outputTokenCount());
+
+            return embeddingStore.add(res.content(), seg);
+          }))
+        .thenApply(__ -> Done.getInstance());
+  }
+}

--- a/src/main/java/akka/ask/indexer/application/IndexWorker.java
+++ b/src/main/java/akka/ask/indexer/application/IndexWorker.java
@@ -1,0 +1,121 @@
+package akka.ask.indexer.application;
+
+import akka.Done;
+import akka.ask.indexer.domain.WorkerState;
+import akka.javasdk.annotations.ComponentId;
+import akka.javasdk.client.ComponentClient;
+import akka.javasdk.workflow.Workflow;
+import akka.javasdk.workflow.WorkflowContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+
+@ComponentId("index-worker")
+public class IndexWorker extends Workflow<WorkerState> {
+
+  private final Logger logger = LoggerFactory.getLogger(getClass());
+
+  private final String workerId;
+  private final ComponentClient componentClient;
+  private final EmbeddingIndexer embeddingIndexer;
+
+  private static final String PROCESSING_FILE_STEP = "processing-file";
+  private static final String NOTIFY_COMPLETION = "notify-completion";
+  private static final String FAILED_FILE_PROCESSING = "failed-file-processing";
+  private static final String NOTIFY_FAILURE = "notify-failure";
+
+  public record IndexRequest(String parentId, Path pathToFile) {}
+
+  public IndexWorker(
+    WorkflowContext context,
+    EmbeddingIndexer embeddingIndexer,
+    ComponentClient componentClient) {
+
+    this.workerId = context.workflowId();
+    this.componentClient = componentClient;
+    this.embeddingIndexer = embeddingIndexer;
+  }
+
+  private WorkerState currentStateOrNew(IndexRequest req) {
+    if (currentState() == null) return WorkerState.init(req.parentId(), req.pathToFile());
+    else return currentState();
+  }
+
+  public Effect<Done> process(IndexRequest req) {
+
+    logger.debug("Worker [{}]: received request to index file: [{}]", workerId, req.pathToFile());
+    var state = currentStateOrNew(req);
+
+    if (state.isIdle())
+      return effects()
+        .updateState(state.indexing(req.pathToFile()))
+        .transitionTo(PROCESSING_FILE_STEP)
+        .thenReply(Done.getInstance());
+    else
+      return effects().error("Worker [" + workerId + "]: already processing file [" + state.pathToFile() + "]");
+
+  }
+
+  @Override
+  public WorkflowDef<WorkerState> definition() {
+    return workflow()
+      .addStep(processing(), maxRetries(3).failoverTo(FAILED_FILE_PROCESSING))
+      .addStep(notifyCompletion())
+      .addStep(failed())
+      .addStep(notifyFailure());
+  }
+
+  private Step processing() {
+    return step(PROCESSING_FILE_STEP)
+      .asyncCall(() -> {
+        var path = currentState().pathToFile();
+        logger.debug("Worker [{}]: indexing file: [{}]", workerId, path);
+        return embeddingIndexer.indexFile(path);
+      })
+      .andThen(Done.class, __ ->
+        effects()
+          .updateState(currentState().idle())
+          .transitionTo(NOTIFY_COMPLETION));
+  }
+
+  private Step notifyCompletion() {
+   return step(NOTIFY_COMPLETION)
+       .asyncCall(() ->
+         // let the parent workflow know that the file has been processed
+         componentClient
+           .forWorkflow(currentState().parentId())
+           .method(RagIndexingWorkflow::markFileAsIndexed)
+           .invokeAsync(currentState().pathToFile())
+       )
+       // pause and wait for the parent workflow to send a new file
+       .andThen(Done.class, cmd -> effects().pause());
+  }
+
+  private Step failed() {
+    // no real asyncCall in this step, but we need to set the Worker to idle
+    // before we notify the parent workflow that it failed to process the file
+    return step(FAILED_FILE_PROCESSING)
+      .asyncCall(() ->
+        CompletableFuture.completedFuture(Done.getInstance()))
+      .andThen(Done.class, __ ->
+        effects()
+          .updateState(currentState().idle())
+          .transitionTo(NOTIFY_FAILURE)
+      );
+  }
+
+  private Step notifyFailure() {
+    return step(NOTIFY_FAILURE)
+      .asyncCall(() ->
+        // let the parent workflow know that it failed to process the file
+        componentClient
+          .forWorkflow(currentState().parentId())
+          .method(RagIndexingWorkflow::markFileAsFailed)
+          .invokeAsync(currentState().pathToFile())
+      )
+      // pause and wait for the parent workflow to send a new file
+      .andThen(Done.class, cmd -> effects().pause());
+  }
+}

--- a/src/main/java/akka/ask/indexer/domain/WorkerState.java
+++ b/src/main/java/akka/ask/indexer/domain/WorkerState.java
@@ -1,0 +1,32 @@
+package akka.ask.indexer.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import java.nio.file.Path;
+
+public record WorkerState(String parentId, Path pathToFile, Status status) {
+
+    public enum Status {
+        INDEXING,
+        IDLE,
+    }
+
+    @JsonIgnore
+    public boolean isIdle() {
+        return status == Status.IDLE;
+    }
+
+    public static WorkerState init(String parent, Path pathToFile) {
+        return new WorkerState(parent, pathToFile, Status.IDLE);
+    }
+
+    public  WorkerState idle() {
+        // note: even when idle it has a pathToFile which is the previously processed file
+        // this information is required to notify the RagIndexingWorkflow that the file has been processed
+        return new WorkerState(parentId, pathToFile, Status.IDLE);
+    }
+
+    public  WorkerState indexing(Path pathToFile) {
+        return new WorkerState(parentId, pathToFile, Status.INDEXING);
+    }
+}

--- a/src/main/java/akka/ask/indexer/domain/package-info.java
+++ b/src/main/java/akka/ask/indexer/domain/package-info.java
@@ -1,5 +1,0 @@
-/**
- * This module is for the domain model of the service. It is should contain plain Java classes that does not
- * depend on the Akka APIs.
- */
-package akka.ask.indexer.domain;

--- a/src/main/resources/flat-doc/invoke-service.md
+++ b/src/main/resources/flat-doc/invoke-service.md
@@ -168,7 +168,7 @@ For a complete reference for the Akka route descriptor, see the [Akka route desc
 CORS can be enabled by configuring at least one allowed origin, for example:
 
 ```bash
-akka route update acme-ecommerce --cors-parentId https://www.acme.org --cors-method GET --cors-method POST
+akka route update acme-ecommerce --cors-origin https://www.acme.org --cors-method GET --cors-method POST
 ```
 
 #### Securing routes

--- a/src/main/resources/flat-doc/invoke-service.md
+++ b/src/main/resources/flat-doc/invoke-service.md
@@ -168,7 +168,7 @@ For a complete reference for the Akka route descriptor, see the [Akka route desc
 CORS can be enabled by configuring at least one allowed origin, for example:
 
 ```bash
-akka route update acme-ecommerce --cors-origin https://www.acme.org --cors-method GET --cors-method POST
+akka route update acme-ecommerce --cors-parentId https://www.acme.org --cors-method GET --cors-method POST
 ```
 
 #### Securing routes

--- a/src/main/resources/static-resources/index.html
+++ b/src/main/resources/static-resources/index.html
@@ -409,7 +409,7 @@
           title: `Conversation from ${formatDate(session.creationDate)}`,
           timestamp: new Date(session.creationDate).toISOString(),
           conversationHistory: session.messages.map(msg => ({
-            type: msg.origin,  // convert 'parentId' to 'type'
+            type: msg.origin,
             message: msg.message
           }))
         }));

--- a/src/main/resources/static-resources/index.html
+++ b/src/main/resources/static-resources/index.html
@@ -409,7 +409,7 @@
           title: `Conversation from ${formatDate(session.creationDate)}`,
           timestamp: new Date(session.creationDate).toISOString(),
           conversationHistory: session.messages.map(msg => ({
-            type: msg.origin,  // convert 'origin' to 'type'
+            type: msg.origin,  // convert 'parentId' to 'type'
             message: msg.message
           }))
         }));


### PR DESCRIPTION
In draft because depends on a new runtime release 
* requires fix https://github.com/lightbend/kalix-runtime/pull/3672
* could benefit from https://github.com/lightbend/kalix-runtime/pull/3673

The indexing is done using two workflows (`RagIndexingWorkflow` and `IndexWorker`).

The job is distributed across the cluster. 

The parent `RagIndexingWorkflow` is responsible to read the files from disk and send to `IndexWorker`. 

The workers are responsible for doing the real work and report back to parent when finished. 

On failure, the worker retries 3 times. After 3 retries, if the file is still failing, it reports back to `RagIndexingWorkflow`.  Such a failing file won't be retried. 

The `RagIndexingWorkflow` keeps track of which files are allocated to which worker. As soon a worker becomes available, the `RagIndexingWorkflow` sends a new file to it. 

This process keep going until all files have being processed. All workflows (parent and children) move to pause status until the process is reinitiated by an user. 

The workflow can be paused by the user and resumed. It can also be aborted. 

When pausing or aborting, the `RagIndexingWorkflow` waits for the in-flight workers to finished their current jobs. 


For this sample, we only have 310 files. Not much and of course a simple loop would also be enough. However, being it a sample to demonstrate RAG, I thought it could be interesting to show users how to build a Workflow that can handle a very large amount of files and distribute the work across the existing nodes.

As discussed in the stand-up today, we could achieve the same using Akka stream and `mapAsyncUnordered` operator. However, the work won't be distributed. 

I agree that the `IndexWorker` may feel overkill for that. If we were using Akka libraries, we would probably build a sharded entity (non-persistent) in other to distribute work across the nodes. 